### PR TITLE
updated context manager and resolved errors

### DIFF
--- a/config/pnnl.goss.gridappsd.cfg
+++ b/config/pnnl.goss.gridappsd.cfg
@@ -35,4 +35,4 @@ proven.advanced_query.path = http://proven:8080/hybrid/rest/v1/repository/getAdv
 
 
 # Power grid model MRID for deployed Field Bus
-field.model.mrid = _C1C3E687-6FFD-C753-582B-632A27E28507
+field.model.mrid = _49AD8E07-3BF9-A4E2-CB8F-C3722F837B62

--- a/src/context.py
+++ b/src/context.py
@@ -1,15 +1,29 @@
-
+import argparse
 import logging
+import time
 from typing import Dict
 
+import gridappsd.field_interface.agents.agents as agents_mod
 import gridappsd.topics as t
+from cimgraph.data_profile import CIM_PROFILE
 from gridappsd import GridAPPSD
 from gridappsd.field_interface.agents import (FeederAgent, SecondaryAreaAgent,
                                               SwitchAreaAgent)
 from gridappsd.field_interface.interfaces import MessageBusDefinition
 
-log = logging.getLogger(__name__)
+cim_profile = CIM_PROFILE.RC4_2021.value
 
+agents_mod.set_cim_profile(cim_profile)
+
+cim = agents_mod.cim
+
+logging.basicConfig(level=logging.DEBUG)
+logging.getLogger('goss').setLevel(logging.ERROR)
+logging.getLogger('stomp.py').setLevel(logging.ERROR)
+
+_log = logging.getLogger(__name__)
+
+#FieldBusManager's request topics. To be used only by context manager user role only.
 REQUEST_FIELD = ".".join((t.PROCESS_PREFIX, "request.field"))
 REQUEST_FIELD_CONTEXT = ".".join((REQUEST_FIELD, "context"))
 
@@ -17,23 +31,24 @@ REQUEST_FIELD_CONTEXT = ".".join((REQUEST_FIELD, "context"))
 class FeederAreaContextManager(FeederAgent):
 
     def __init__(self,
-                 upstream: MessageBusDefinition,
-                 downstream: MessageBusDefinition,
-                 config: Dict,
-                 area: Dict = None,
-                 simulation_id: str = None) -> None:
+                 upstream_message_bus_def: MessageBusDefinition,
+                 downstream_message_bus_def: MessageBusDefinition,
+                 agent_config: Dict,
+                 feeder_dict: Dict = None,
+                 simulation_id: str = None):
 
         self.ot_connection = GridAPPSD()
-        if area is None:
-            request = {'modelId': downstream.id}
-            area = self.ot_connection.get_response(
+        if feeder_dict is None:
+            request = {'modelId': downstream_message_bus_def.id}
+            feeder_dict = self.ot_connection.get_response(
                 REQUEST_FIELD_CONTEXT, request, timeout=10)['data']
 
-        super().__init__(upstream, downstream, config, area, simulation_id)
+        super().__init__(upstream_message_bus_def, downstream_message_bus_def,
+                         agent_config, feeder_dict, simulation_id)
 
-        # Override agent_id to a static value
-        self.agent_id = downstream.id + '.context_manager'
-
+        #Override agent_id to a static value
+        self.agent_id = downstream_message_bus_def.id + '.context_manager'
+        
         self.context = None
 
         self.registered_agents = {}
@@ -45,15 +60,14 @@ class FeederAreaContextManager(FeederAgent):
 
     def on_request(self, message_bus, headers: Dict, message):
 
-        log.debug(f"Received request: {message}")
+        _log.debug(f"Received request: {message}")
 
         if message['request_type'] == 'get_context':
             del message['request_type']
             reply_to = headers['reply-to']
             if self.context is None:
-                self.context = self.ot_connection.get_response(
-                    REQUEST_FIELD_CONTEXT, message)
-            message_bus.send(reply_to, self.context)
+                self.context = self.ot_connection.get_response(REQUEST_FIELD_CONTEXT, message)
+            message_bus.send(reply_to,self.context)
 
         elif message['request_type'] == 'register_agent':
             self.ot_connection.send(t.REGISTER_AGENT_QUEUE, message)
@@ -63,28 +77,32 @@ class FeederAreaContextManager(FeederAgent):
         elif message['request_type'] == 'get_agents':
             reply_to = headers['reply-to']
             message_bus.send(reply_to, self.registered_agents)
+
+    def on_measurement(self, headers: Dict, message):
+        pass
 
 
 class SwitchAreaContextManager(SwitchAreaAgent):
 
     def __init__(self,
-                 upstream: MessageBusDefinition,
-                 downstream: MessageBusDefinition,
-                 config: Dict,
-                 area: Dict = None,
-                 simulation_id: str = None) -> None:
+                 upstream_message_bus_def: MessageBusDefinition,
+                 downstream_message_bus_def: MessageBusDefinition,
+                 agent_config: Dict,
+                 switch_area_dict: Dict = None,
+                 simulation_id: str = None):
 
         self.ot_connection = GridAPPSD()
-        if area is None:
-            request = {'areaId': downstream.id}
-            area = self.ot_connection.get_response(
+        if switch_area_dict is None:
+            request = {'areaId': downstream_message_bus_def.id}
+            switch_area_dict = self.ot_connection.get_response(
                 REQUEST_FIELD_CONTEXT, request, timeout=10)['data']
 
-        super().__init__(upstream, downstream, config, area, simulation_id)
+        super().__init__(upstream_message_bus_def, downstream_message_bus_def,
+                         agent_config, switch_area_dict, simulation_id)
 
-        # Override agent_id to a static value
-        self.agent_id = downstream.id + '.context_manager'
-
+        #Override agent_id to a static value
+        self.agent_id = downstream_message_bus_def.id + '.context_manager'
+        
         self.context = None
 
         self.registered_agents = {}
@@ -92,14 +110,13 @@ class SwitchAreaContextManager(SwitchAreaAgent):
 
     def on_request(self, message_bus, headers: Dict, message):
 
-        log.debug(f"Received request: {message}")
+        _log.debug(f"Received request: {message}")
 
         if message['request_type'] == 'get_context':
             reply_to = headers['reply-to']
             if self.context is None:
-                self.context = self.ot_connection.get_response(
-                    REQUEST_FIELD_CONTEXT, message)
-            message_bus.send(reply_to, self.context)
+                self.context = self.ot_connection.get_response(REQUEST_FIELD_CONTEXT, message)
+            message_bus.send(reply_to,self.context)
 
         elif message['request_type'] == 'register_agent':
             self.ot_connection.send(t.REGISTER_AGENT_QUEUE, message)
@@ -109,28 +126,32 @@ class SwitchAreaContextManager(SwitchAreaAgent):
         elif message['request_type'] == 'get_agents':
             reply_to = headers['reply-to']
             message_bus.send(reply_to, self.registered_agents)
+
+    def on_measurement(self, headers: Dict, message):
+        pass
 
 
 class SecondaryAreaContextManager(SecondaryAreaAgent):
 
     def __init__(self,
-                 upstream: MessageBusDefinition,
-                 downstream: MessageBusDefinition,
-                 config: Dict,
-                 area: Dict = None,
-                 simulation_id: str = None) -> None:
+                 upstream_message_bus_def: MessageBusDefinition,
+                 downstream_message_bus_def: MessageBusDefinition,
+                 agent_config: Dict,
+                 secondary_area_dict: Dict = None,
+                 simulation_id: str = None):
 
         self.ot_connection = GridAPPSD()
-        if area is None:
-            request = {'areaId': downstream.id}
-            area = self.ot_connection.get_response(
+        if secondary_area_dict is None:
+            request = {'areaId': downstream_message_bus_def.id}
+            secondary_area_dict = self.ot_connection.get_response(
                 REQUEST_FIELD_CONTEXT, request, timeout=10)['data']
 
-        super().__init__(upstream, downstream, config, area, simulation_id)
+        super().__init__(upstream_message_bus_def, downstream_message_bus_def,
+                         agent_config, secondary_area_dict, simulation_id)
 
-        # Override agent_id to a static value
-        self.agent_id = downstream.id + '.context_manager'
-
+        #Override agent_id to a static value
+        self.agent_id = downstream_message_bus_def.id + '.context_manager'
+        
         self.context = None
 
         self.registered_agents = {}
@@ -138,15 +159,15 @@ class SecondaryAreaContextManager(SecondaryAreaAgent):
 
     def on_request(self, message_bus, headers: Dict, message):
 
-        log.debug(f"Received request: {message}")
-        log.debug(f"Received request: {headers}")
+        _log.debug(f"Received request: {message}")
+        _log.debug(f"Received request: {headers}")
 
         if message['request_type'] == 'get_context':
             reply_to = headers['reply-to']
             if self.context is None:
-                self.context = self.ot_connection.get_response(
-                    REQUEST_FIELD_CONTEXT, message)
-            message_bus.send(reply_to, self.context)
+                self.context = self.ot_connection.get_response(REQUEST_FIELD_CONTEXT, message)
+            message_bus.send(reply_to,self.context)
+
 
         elif message['request_type'] == 'register_agent':
             self.ot_connection.send(t.REGISTER_AGENT_QUEUE, message)
@@ -156,3 +177,7 @@ class SecondaryAreaContextManager(SecondaryAreaAgent):
         elif message['request_type'] == 'get_agents':
             reply_to = headers['reply-to']
             message_bus.send(reply_to, self.registered_agents)
+        
+    def on_measurement(self, headers: Dict, message):
+        pass
+


### PR DESCRIPTION
- Updated the code with latest Context Manager 
- Removed spawn functions

Still getting this error with IEEE13 node model
```
DEBUG:__main__:'NoneType' object is not subscriptable
DEBUG:__main__:Traceback (most recent call last):
  File "src/main.py", line 142, in run
    spawn_agents(sim)
  File "src/main.py", line 120, in spawn_agents
    secondary_agent = SampleSecondaryAreaAgent(
  File "/home/poorva/git/gridappsd/distributed-energy-coordinator/src/agents.py", line 146, in __init__
    self.bus_info.update(qy.query_power_electronics(self.secondary_area))
  File "/home/poorva/git/gridappsd/distributed-energy-coordinator/src/queries.py", line 187, in query_power_electronics
    if pec_phs.phase[0] == "A":
TypeError: 'NoneType' object is not subscriptable
```